### PR TITLE
docs: streamline CLAUDE.md with /init guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,46 +1,87 @@
-# Claude Instructions
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Project Overview
 
-Indonesian accounting application for small businesses. Spring Boot 4.0 + Thymeleaf + PostgreSQL. Licensed under Apache License 2.0.
+**Balaka** — Indonesian accounting application for small businesses. Spring Boot 4.0.4 + Thymeleaf + PostgreSQL 18, Java 25. Licensed Apache 2.0. Maven artifact `com.artivisi:accounting-finance`, current version `2026.05-SNAPSHOT`.
 
-## Current Status
+All 20 phases complete — see `docs/06-implementation-plan.md` for status and `docs/01-features-and-roadmap.md` for feature inventory.
 
-- **Phase 0:** ✅ Complete (project setup, auth, CI/CD)
-- **Phase 1:** ✅ Complete (Core Accounting MVP)
-- **Phase 2:** ✅ Complete (Tax Compliance + Cash Flow)
-- **Phase 3:** ✅ Complete (Payroll + RBAC + Employee Self-Service)
-- **Phase 4:** ✅ Complete (Fixed Assets)
-- **Phase 5:** ✅ Complete (Inventory & Production)
-  - 5.1 Product Master: ✅ Complete
-  - 5.2 Inventory Transactions: ✅ Complete
-  - 5.3 Inventory Reports: ✅ Complete
-  - 5.4 Simple Production (BOM): ✅ Complete
-  - 5.5 Integration with Sales: ✅ Complete
-- **Phase 6:** ✅ Complete (Security Hardening)
-- **Phase 7:** ✅ Complete (API Foundation — OAuth 2.0 device auth, 7 API controllers, pagination, device token management UI)
-- **Phase 8:** ✅ Complete (Bank Reconciliation)
-- **Phase 9:** ✅ Complete (Analytics & Insights — 9.2 Smart Alerts ✅, 9.3 Transaction Tags ✅)
-- **AI Analysis Reports:** ✅ Complete (structured report publishing with per-industry KPIs)
-- **Phase 10:** ✅ Complete (Invoice & Bill Management — invoices, vendor bills, bill API, payment tracking, aging reports, customer/vendor statements)
-- **Phase 11:** ✅ Complete (Recurring Transactions — templates, scheduling, auto-posting)
-- **Phase 12:** ✅ Complete (Tax Data Management — 12.1 PPN formula fix, 12.2 tax detail entry UI, 12.3 tax detail & document API, 12.4 auto-populate tax details, 12.5 client management UI, 12.6 fiscal period management, 12.7 tax report enhancements, 12.8 tax deadline updates, 12.9 retrofit 2025 data, 12.10 tax export API, 12.11 PPN docs update)
-- **Phase 13:** ✅ Complete (OpenAPI Migration — springdoc-openapi 3.0.1, 11 @Tag controllers, x- extensions, Swagger UI)
-- **Phase 14:** ✅ Complete (Fiscal Adjustments API)
-- **Phase 15:** ✅ Complete (Payroll API + PPh 21)
-- **Bug Fixes:** ✅ Complete (BUG-001 PPN rounding, BUG-002 PUT broken DRAFTs, BUG-003 PUT overrides 409, BUG-004 empty journalEntries)
-- **Phase 16:** ✅ Complete (User Manual Revamp — AI-Operated Lifecycle)
-- **Phase 17:** ✅ Complete (SPT Tahunan Badan Data Export — L1 rekonsiliasi fiskal, L4 penghasilan final, L9 penyusutan DJP format, transkrip 8A, e-Bupot PPh 21 annual, fiscal loss carryforward, SPT checklist dashboard)
-- **Phase 18:** ✅ Complete (PPh 21 TER Method — PMK 168/2023, TerCategory enum, monthly TER Jan–Nov, December reconciliation, web calculator)
-- **Phase 19:** ✅ Complete (Scheduled Payroll — automated monthly payroll run creation, CRUD API, daily scheduler with startup catch-up)
-- **Phase 20:** ✅ Complete (Free-Form Journal Entry API — `POST /api/transactions/journal-entry`, arbitrary debit/credit lines, no template required, for closing/adjusting/opening entries)
-- **BUG-014:** ✅ Complete (Tax export excluded closing journal from P&L via `closingEntry` boolean)
-- **SPT Lampiran Export:** ✅ Complete (`GET /api/tax-export/spt-tahunan/lampiran?year=`, consolidated Coretax-ready data)
-- **BUG-016/017/018:** ✅ Complete (Transkrip 8A asset mapping, Lampiran I pasal field, accountSlots lineOrder fallback)
-- **Period Report:** ✅ Complete (`/reports/period` — fiscal period dropdown, closing-entry-excluded P&L)
-- **Sidebar Reorg:** ✅ Complete (Master Data separated from Pengaturan)
-- **Tax Filing (FR-001–006):** ✅ Complete (L1 non-operating expenses fix, L9 depreciation fallback, PKP rounding, excludeClosing API param, financial statements PDF, Coretax SPT export)
-- See `docs/06-implementation-plan.md` for full plan
+## Architecture
+
+```
+User → Controller (MVC) → Service → Repository → PostgreSQL
+         ↓
+    Thymeleaf Templates (HTMX + Alpine.js, Bootstrap + Tailwind)
+```
+
+**Transaction-centric design:** There are no standalone journal entries. Every `journal_entry` row is generated from a `transaction` + `journal_template`, with user-selected accounts resolved via `transaction_account_mappings` and amounts computed by the SpEL formula engine. `JournalService` enforces double-entry; `FormulaService` evaluates SpEL using `SimpleEvaluationContext.forReadOnlyDataBinding()` (no type refs, constructors, or bean refs).
+
+**System vs user templates:** Templates with `is_system=true` (e.g. payroll, depreciation, year-end closing) are owned by internal services and must not be edited by users. User templates (e.g. revenue, expenses, transfers) are customizable.
+
+**Single-tenant:** One company per database instance. No multi-tenancy logic in code.
+
+**Layout:** 60 controllers, 74 services, 88 JPA entities (UUID PKs, soft-delete pattern, audit fields on `BaseEntity`). API controllers live under `controller/api/` — only this package is scanned by springdoc-openapi.
+
+## Common Commands
+
+```bash
+# Requires: Java 25, Docker (for Testcontainers — PostgreSQL + ZAP)
+# Maven wrapper is bundled; no system Maven needed.
+
+# Run all tests (unit + integration + functional + DAST, 60–90 min)
+# NEVER run multiple instances in parallel — Testcontainers will conflict.
+nohup ./mvnw test > target/test-output.log 2>&1 &
+
+# Run a single functional test (Playwright-driven, headless by default)
+./mvnw test -Dtest=MfgBomTest
+
+# Debug a functional test with a visible browser
+./mvnw test -Dtest=MfgBomTest -Dplaywright.headless=false -Dplaywright.slowmo=100
+
+# SpotBugs + FindSecBugs (static security)
+./mvnw spotbugs:check          # results in target/spotbugsXml.xml
+
+# OWASP ZAP DAST (excluded from default surefire run via excludedGroups)
+./mvnw test -Dtest=ZapDastTest -Ddast.enabled=true                # full active scan (~20 min)
+./mvnw test -Dtest=ZapDastTest -Ddast.enabled=true -Ddast.quick=true  # passive only (~5 min)
+
+# First-time Ubuntu setup (installs Playwright browser deps)
+./setup-ubuntu.sh
+```
+
+Frontend assets (Tailwind, Vite) are built automatically during `generate-resources` via the `frontend-maven-plugin` (Node 22.12.0 / npm 11.7.0) from `src/main/frontend/`. No manual `npm install` needed.
+
+## Runtime Configuration
+
+App listens on **port 10000** (not Spring's default 8080). Defaults expect PostgreSQL on `localhost:12345` with `sslmode=require`. Override via env vars:
+
+| Env var | Purpose |
+|---------|---------|
+| `DATABASE_URL`, `DATABASE_USERNAME`, `DATABASE_PASSWORD` | DB connection |
+| `APP_ENCRYPTION_KEY` | AES-256-GCM key for PII fields (`openssl rand -base64 32`) |
+| `TELEGRAM_BOT_*` | Telegram bot integration (disabled by default) |
+| `GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_CLOUD_VISION_ENABLED` | Receipt OCR |
+| `APP_DEMO_MODE` | Shows reset banner on every page |
+
+Session timeout is 15 minutes; cookies are `HttpOnly` + `SameSite=strict`. Hibernate runs with `ddl-auto=validate` — schema is owned by Flyway.
+
+## Database
+
+- Production migrations: `src/main/resources/db/migration/` (V001 security, V002 core schema, V003 feature schema, V004 seed data).
+- **Migration policy:** Pre-production — *modify* existing V001–V004 rather than adding new files. Modifying an already-applied migration requires manual schema fix + checksum update in `flyway_schema_history`; see `docs/03-operations-guide.md` Troubleshooting.
+- Integration tests: V900–V912 under `src/test/resources/db/test/integration/` (preloaded data for unit/service/security tests).
+- Functional tests: **no migrations** — data is loaded via `@TestConfiguration` initializers from `industry-seed/{it-service,online-seller,coffee-shop,campus}/seed-data/` (COA, templates, products, BOMs, etc.) using `DataImportService`.
+
+## Development Guidelines
+
+1. **Feature completion criteria:** Item is only checked when verified by a Playwright functional test.
+2. **No fallback/default values:** Throw errors instead of silently handling missing data.
+3. **Technical language:** No marketing speak in docs.
+4. **Test-driven:** Write functional tests for new features.
+5. **Migration strategy:** Modify existing migrations instead of creating new ones (pre-production — see Database section).
+6. **Code quality:** Maintain SpotBugs 0-issue status. Any new exclusion in `spotbugs-exclude.xml` must include a comprehensive justification with mitigation details.
 
 ## Key Files
 
@@ -52,85 +93,15 @@ Indonesian accounting application for small businesses. Spring Boot 4.0 + Thymel
 | Tax Compliance | `docs/04-tax-compliance.md` |
 | Implementation Plan | `docs/06-implementation-plan.md` |
 | ADRs | `docs/adr/` |
-| User Manual | `docs/user-manual/*.md` (20 files, 17 sections + appendices) |
-| User Manual Guidelines | `docs/user-manual-creation-guidelines.md` (section extraction rules, duplicate prevention) |
-| Security Exclusions | `spotbugs-exclude.xml` (SpotBugs false positives with justifications) |
-| Entities | `src/main/java/.../entity/` |
-| Services | `src/main/java/.../service/` |
-| Controllers | `src/main/java/.../controller/` |
+| User Manual | `docs/user-manual/*.md` |
+| User Manual Guidelines | `docs/user-manual-creation-guidelines.md` |
+| Security Exclusions | `spotbugs-exclude.xml` |
+| Entities / Services / Controllers | `src/main/java/com/artivisi/accountingfinance/{entity,service,controller}/` |
+| API Controllers (scanned by OpenAPI) | `src/main/java/com/artivisi/accountingfinance/controller/api/` |
 | Templates | `src/main/resources/templates/` |
-| Migrations (Production) | `src/main/resources/db/migration/` (V001-V004) |
-| Test Migrations (Integration) | `src/test/resources/db/test/integration/` (V900-V912) |
-| Industry Seed Packs | `industry-seed/{it-service,online-seller,coffee-shop,campus}/` (loaded via DataImportService) |
-| Functional Tests | `src/test/java/.../functional/` |
+| Production migrations | `src/main/resources/db/migration/` (V001–V004) |
+| Integration-test migrations | `src/test/resources/db/test/integration/` (V900–V912) |
+| Industry seed packs | `industry-seed/{it-service,online-seller,coffee-shop,campus}/` |
+| Functional tests | `src/test/java/com/artivisi/accountingfinance/functional/` |
 | Infrastructure (Pulumi) | `deploy/pulumi/` |
 | Configuration (Ansible) | `deploy/ansible/` |
-
-## Development Guidelines
-
-1. **Feature completion criteria:** Item is only checked when verified by Playwright functional test
-2. **No fallback/default values:** Throw errors instead of silently handling missing data
-3. **Technical language:** No marketing speak, strictly technical documentation
-4. **Test-driven:** Write functional tests for new features
-5. **Migration strategy:** Modify existing migrations instead of creating new ones (pre-production)
-6. **Code quality:** Maintain SpotBugs 0-issue status. Any new exclusions in `spotbugs-exclude.xml` must have comprehensive justifications with mitigation details
-
-## Running the App
-
-```bash
-# First-time setup on Ubuntu (install Playwright browsers)
-./setup-ubuntu.sh
-
-# Run all tests (unit, integration, functional, DAST)
-# Requires Docker for Testcontainers (PostgreSQL, ZAP)
-# IMPORTANT: Full test suite takes 60-90 minutes. Always run in background
-# with log capture. NEVER run multiple instances simultaneously.
-./mvnw test 2>&1 | tee target/test-output.log
-# Or in background:
-nohup ./mvnw test > target/test-output.log 2>&1 &
-
-# Run specific functional test
-./mvnw test -Dtest=MfgBomTest
-
-# Run with visible browser (debugging)
-./mvnw test -Dtest=MfgBomTest -Dplaywright.headless=false -Dplaywright.slowmo=100
-
-# Run SpotBugs security analysis
-./mvnw spotbugs:check
-# Results: target/spotbugsXml.xml
-
-# Run only DAST tests
-./mvnw test -Dtest=ZapDastTest
-# Results: target/security-reports/zap-*.html
-
-# Run DAST in quick mode (passive scan only, ~1 min)
-./mvnw test -Dtest=ZapDastTest -Ddast.quick=true
-```
-
-## Database
-
-- PostgreSQL via Testcontainers (tests)
-- Production migrations: V001-V004 (V001 security, V002 core schema, V003 feature schema, V004 seed data)
-- **Migration caveat:** Modifying already-applied migrations requires manual schema fix on production + checksum update in `flyway_schema_history`. See `docs/03-operations-guide.md` Troubleshooting section.
-- Test data:
-  - Functional tests: NO migrations - all data loaded via `@TestConfiguration` initializers from industry-seed/ packs
-  - Integration tests: V900-V912 (preloaded data for unit/service/security tests)
-- Industry seed packs: `industry-seed/{it-service,online-seller,coffee-shop}/seed-data/` (COA, templates, products, BOMs, etc.)
-
-## Architecture
-
-```
-User → Controller (MVC) → Service → Repository → PostgreSQL
-         ↓
-    Thymeleaf Templates (HTMX + Alpine.js)
-```
-
-## Current Release
-
-**2026.04-RELEASE** tagged. See `docs/releases/2026.04-RELEASE.md` for release notes.
-
-## Current Focus
-
-Phases 0-20 complete.
-
-See `docs/06-implementation-plan.md` for full plan


### PR DESCRIPTION
## Summary
- Drops the phase-by-phase status log from `CLAUDE.md` — it duplicated `docs/06-implementation-plan.md` and went stale with every release.
- Adds non-obvious facts useful to Claude Code (and new contributors) when first entering the repo: Java 25, app port 10000, required env vars, transaction-centric template + SpEL model, the `controller/api/` package OpenAPI scans, frontend build wired into Maven, DAST opt-in flag.
- Adds the standard `/init` header so future `claude init` runs recognize the file.

Net: -107 / +78 lines, single-file change to `CLAUDE.md`.

## Test plan
- [ ] Render `CLAUDE.md` on GitHub and confirm formatting (tables, code blocks).
- [ ] Confirm no other files modified: `git show --stat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)